### PR TITLE
Add Scala 2.12/2.11 cross-building (with necessary dependency updates)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,18 +4,20 @@ name := "routerx"
 
 organization := "com.stabletechs"
 
-version := "1.1.2"
+version := "1.1.3-SNAPSHOT"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.1"
+
+crossScalaVersions := Seq("2.11.8", "2.12.1")
 
 homepage := Some(url("http://stabletechs.com/"))
 
 licenses += ("MIT License", url("http://www.opensource.org/licenses/mit-license.php"))
 
-libraryDependencies += "com.stabletechs" %%% "likelib" % "0.1.2"
-libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.0"
-libraryDependencies += "com.lihaoyi" %%% "scalarx" % "0.3.1"
-libraryDependencies += "com.lihaoyi" %%% "upickle" % "0.4.0"
+libraryDependencies += "com.stabletechs" %%% "likelib" % "0.1.3-SNAPSHOT"
+libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "0.9.1"
+libraryDependencies += "com.lihaoyi" %%% "scalarx" % "0.3.2"
+libraryDependencies += "com.lihaoyi" %%% "upickle" % "0.4.4"
 libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value 
 
 jsDependencies += RuntimeDOM
@@ -23,7 +25,7 @@ jsDependencies += RuntimeDOM
 skip in packageJSDependencies := false
 
 // uTest settings
-libraryDependencies += "com.lihaoyi" %%% "utest" % "0.3.1"
+libraryDependencies += "com.lihaoyi" %%% "utest" % "0.4.5"
 testFrameworks += new TestFramework("utest.runner.Framework")
 
 persistLauncher in Compile := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.9")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.15")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.1")
 

--- a/src/test/scala/routerx/LocalLinkTest.scala
+++ b/src/test/scala/routerx/LocalLinkTest.scala
@@ -6,7 +6,7 @@ import org.scalajs.dom
 import scala.concurrent.{ExecutionContext, Future}
 
 object LocalLinkTest extends TestSuite with implicits.Defaults {
-  import utest.ExecutionContext.RunNow
+  import utest.framework.ExecutionContext.RunNow
 
   case class UserId(value: Long) extends AnyVal
   object UserId {


### PR DESCRIPTION
This pull request adds cross-compilation on Scala 2.11 and 2.12, rather than just 2.11. I had to update Scala.js and various dependencies to be compatible with 2.12. likelib also needs to be cross-compiled on 2.12, so I'm sending a pull request for that too.

Feel free to use any of this if you want to publish a Scala 2.12 version of this lib!